### PR TITLE
Fix the default port binding.

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -2,7 +2,7 @@
 var debug = require('debug')('my-application');
 var app = require('../app');
 
-app.set('port', process.env.PORT || 3000);
+app.set('port', process.env.PORT || '3000');
 
 var server = app.listen(app.get('port'), function() {
   debug('Express server listening on port ' + server.address().port);


### PR DESCRIPTION
I noticed when deploying to k8s that when PORT
was not specified in the env express does not
bind to port 3000 properly, so the k8s health checks
failed and left the app unavailable I think this 
is because express is expecting a string not a number
